### PR TITLE
Add option to save NFT admin resource to contract account

### DIFF
--- a/packages/nft/src/collections/OnChainBlindCollection.ts
+++ b/packages/nft/src/collections/OnChainBlindCollection.ts
@@ -43,13 +43,22 @@ export default class OnChainBlindCollection extends BaseCollection {
     });
   }
 
-  async deployContract(publicKey: PublicKey, hashAlgo: HashAlgorithm, placeholderImage: string): Promise<string> {
+  async deployContract(
+    publicKey: PublicKey,
+    hashAlgo: HashAlgorithm,
+    placeholderImage: string,
+    options?: {
+      saveAdminResourceToContractAccount?: boolean,
+    },
+  ): Promise<string> {
     const transaction = await OnChainBlindGenerator.deploy();
 
     const contractCode = await this.getContract();
     const contractCodeHex = Buffer.from(contractCode, 'utf-8').toString('hex');
 
     const sigAlgo = publicKey.signatureAlgorithm();
+
+    const saveAdminResourceToContractAccount = options?.saveAdminResourceToContractAccount ?? false;
 
     const response = await fcl.send([
       fcl.transaction(transaction),
@@ -60,6 +69,7 @@ export default class OnChainBlindCollection extends BaseCollection {
         fcl.arg(SignatureAlgorithm.toCadence(sigAlgo), t.UInt8),
         fcl.arg(HashAlgorithm.toCadence(hashAlgo), t.UInt8),
         fcl.arg(placeholderImage, t.String),
+        fcl.arg(saveAdminResourceToContractAccount, t.Bool),
       ]),
       fcl.limit(1000),
 

--- a/packages/nft/src/collections/OnChainBlindCollection.ts
+++ b/packages/nft/src/collections/OnChainBlindCollection.ts
@@ -48,7 +48,7 @@ export default class OnChainBlindCollection extends BaseCollection {
     hashAlgo: HashAlgorithm,
     placeholderImage: string,
     options?: {
-      saveAdminResourceToContractAccount?: boolean,
+      saveAdminResourceToContractAccount?: boolean;
     },
   ): Promise<string> {
     const transaction = await OnChainBlindGenerator.deploy();

--- a/packages/nft/src/collections/OnChainCollection.ts
+++ b/packages/nft/src/collections/OnChainCollection.ts
@@ -25,10 +25,10 @@ export default class OnChainCollection extends BaseCollection {
   }
 
   async deployContract(
-    publicKey: PublicKey, 
+    publicKey: PublicKey,
     hashAlgo: HashAlgorithm,
     options?: {
-      saveAdminResourceToContractAccount?: boolean,
+      saveAdminResourceToContractAccount?: boolean;
     },
   ): Promise<string> {
     const transaction = await OnChainGenerator.deploy();

--- a/packages/nft/src/collections/OnChainCollection.ts
+++ b/packages/nft/src/collections/OnChainCollection.ts
@@ -24,13 +24,21 @@ export default class OnChainCollection extends BaseCollection {
     });
   }
 
-  async deployContract(publicKey: PublicKey, hashAlgo: HashAlgorithm): Promise<string> {
+  async deployContract(
+    publicKey: PublicKey, 
+    hashAlgo: HashAlgorithm,
+    options?: {
+      saveAdminResourceToContractAccount?: boolean,
+    },
+  ): Promise<string> {
     const transaction = await OnChainGenerator.deploy();
 
     const contractCode = await this.getContract();
     const contractCodeHex = Buffer.from(contractCode, 'utf-8').toString('hex');
 
     const sigAlgo = publicKey.signatureAlgorithm();
+
+    const saveAdminResourceToContractAccount = options?.saveAdminResourceToContractAccount ?? false;
 
     const response = await fcl.send([
       fcl.transaction(transaction),
@@ -40,6 +48,7 @@ export default class OnChainCollection extends BaseCollection {
         fcl.arg(publicKey.toHex(), t.String),
         fcl.arg(SignatureAlgorithm.toCadence(sigAlgo), t.UInt8),
         fcl.arg(HashAlgorithm.toCadence(hashAlgo), t.UInt8),
+        fcl.arg(saveAdminResourceToContractAccount, t.Bool),
       ]),
       fcl.limit(1000),
 

--- a/packages/nft/src/templates/cadence/on-chain-blind/transactions/deploy.cdc
+++ b/packages/nft/src/templates/cadence/on-chain-blind/transactions/deploy.cdc
@@ -4,7 +4,8 @@ transaction(
     publicKeyHex: String,
     signatureAlgorithm: UInt8,
     hashAlgorithm: UInt8,
-    placeholderImage: String
+    placeholderImage: String,
+    saveAdminResourceToContractAccount: Bool,
 ) {
     prepare(admin: AuthAccount) {
         let account = AuthAccount(payer: admin)
@@ -20,11 +21,20 @@ transaction(
             weight: 1000.0
         )
 
-        account.contracts.add(
-            name: contractName,
-            code: contractCode.decodeHex(),
-            admin,
-            placeholderImage
-        )
+        if saveAdminResourceToContractAccount {
+            account.contracts.add(
+                name: contractName,
+                code: contractCode.decodeHex(),
+                account,
+                placeholderImage,
+            )
+        } else {
+            account.contracts.add(
+                name: contractName,
+                code: contractCode.decodeHex(),
+                admin,
+                placeholderImage,
+            )
+        }
     }
 }

--- a/packages/nft/src/templates/cadence/on-chain/transactions/deploy.cdc
+++ b/packages/nft/src/templates/cadence/on-chain/transactions/deploy.cdc
@@ -3,7 +3,8 @@ transaction(
     contractCode: String,
     publicKeyHex: String,
     signatureAlgorithm: UInt8,
-    hashAlgorithm: UInt8
+    hashAlgorithm: UInt8,
+    saveAdminResourceToContractAccount: Bool,
 ) {
     prepare(admin: AuthAccount) {
         let account = AuthAccount(payer: admin)
@@ -19,10 +20,18 @@ transaction(
             weight: 1000.0
         )
 
-        account.contracts.add(
-            name: contractName,
-            code: contractCode.decodeHex(),
-            admin
-        )
+        if saveAdminResourceToContractAccount {
+            account.contracts.add(
+                name: contractName,
+                code: contractCode.decodeHex(),
+                account
+            )
+        } else {
+            account.contracts.add(
+                name: contractName,
+                code: contractCode.decodeHex(),
+                admin
+            )
+        }
     }
 }


### PR DESCRIPTION
This update gives developers the option to use the NFT contract account as the owner (i.e. minter) account.

I'd like to find a cleaner way to enable advanced functionality like this, so far now the option is a bit "scary" to discourage misuse.

```js
// The temporary owner only signs the transaction to deploy the contract.
const tempOwner = new Authorizer({ ... });

const collection = new OnChainCollection({ owner: tempOwner })

const contractAddress = await collection.deployContract(
  publicKey,
  HashAlgorithm.SHA3_256,
  { saveAdminResourceToContractAccount: true }
);

// Set the contract as the collection owner
const owner = new Authorizer({ address: contractAddress, keyIndex: 0, signer });

collection.setOwner(owner);